### PR TITLE
feat(ui-kit -> panel): add properties to panel (backwards compitable)

### DIFF
--- a/packages/ui-kit/src/Panel/Panel.fixture.tsx
+++ b/packages/ui-kit/src/Panel/Panel.fixture.tsx
@@ -1,7 +1,7 @@
 import { Panel } from '.';
 
 export default (
-  <div style={{ display: 'flex', gap: '1em', flexDirection: 'row' }}>
+  <div style={{ display: 'flex', gap: '1em', flexDirection: 'row', flexWrap: 'wrap' }}>
     <Panel header={<div style={{ fontSize: '1.2em', whiteSpace: 'pre' }}>Custom title</div>} onHeaderClick={console.log}>
       <div style={{ height: '400px', display: 'flex', margin: 'auto' }}>
         <div style={{ margin: 'auto', padding: '1em' }}>Content</div>
@@ -22,5 +22,11 @@ export default (
         </div>
       </Panel>
     </div>
+    
+    <Panel header="Resizable panel" resize='vertical' minContentHeightPx={40}>
+      <div style={{ display: 'flex', margin: 'auto' }}>
+        <div style={{ margin: 'auto', padding: '2em' }}>Content</div>
+      </div>
+    </Panel>
   </div>
 );

--- a/packages/ui-kit/src/Panel/index.tsx
+++ b/packages/ui-kit/src/Panel/index.tsx
@@ -23,6 +23,10 @@ interface Panel extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElem
     onModalClick: () => void
     showInModal: boolean;
   };
+  minContentHeightPx?: number;
+  contentContainerRef?: (node: HTMLDivElement) => void;
+  contentClassName?: string;
+  resize?: 'vertical' | 'horizontal' | 'both' | 'none'
 }
 
 export function Panel({
@@ -36,6 +40,10 @@ export function Panel({
   ref,
   isOpen = true,
   modal,
+  minContentHeightPx,
+  contentContainerRef,
+  contentClassName,
+  resize = 'none',
   ...rest
 }: React.PropsWithChildren<Panel>) {
 
@@ -56,9 +64,13 @@ export function Panel({
         </div>
       </div>
     )}
-    <div className={cn(s.contentContainer, isOpen ? s.show : s.collapse)}>
+    {isOpen && <div
+      className={cn(s.contentContainer, contentClassName)}
+      ref={contentContainerRef}
+      style={{ minHeight: minContentHeightPx || 'unset', resize: resize }}
+    >
       {children}
-    </div>
+    </div>}
   </Card>
 
 

--- a/packages/ui-kit/src/Panel/style.module.css
+++ b/packages/ui-kit/src/Panel/style.module.css
@@ -26,13 +26,8 @@
 }
 
 .contentContainer{
-  &.show {
-    height: 100%;
-  }
-
-  &.collapse{
-    height: 0;
-  }
+  height: 100%;
+  overflow: auto;
 }
 
 .panelIcon {


### PR DESCRIPTION
Panel opens a ref to it's content container, class name and resizible option which is easy to read
![image](https://user-images.githubusercontent.com/50058726/193075556-e30edd27-5c45-4ccf-ba13-9c16c5a4ca9c.png)
Also min-height is a separate value that can change dynamically