### PR TITLE
feat(ui-kit select): Add top placeholder for Select component [backwards compitable]

### DIFF
--- a/packages/ui-kit/src/Select/components/SelectButton/style.module.css
+++ b/packages/ui-kit/src/Select/components/SelectButton/style.module.css
@@ -142,6 +142,7 @@
     & .topPlaceholder{
       top: -10px;
       background: var(--base-weak);
+      padding: 0 4px;
     }
   }
 

--- a/packages/ui-kit/src/Select/components/SelectButton/style.module.css
+++ b/packages/ui-kit/src/Select/components/SelectButton/style.module.css
@@ -131,4 +131,21 @@
   &.error .selectBox {
     box-shadow: 0 0 0 1px var(--error-strong);
   }
+
+  & .topPlaceholder{
+    transition: 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+    position: absolute;
+    top: 8px;
+  }
+  
+  & .hasValue{
+    & .topPlaceholder{
+      top: -10px;
+      background: var(--base-weak);
+    }
+  }
+
+  & button:focus .topPlaceholder{
+    color: var(--complimentary-strong-down);
+  }
 }

--- a/packages/ui-kit/src/Select/fixtures/Select.fixture.tsx
+++ b/packages/ui-kit/src/Select/fixtures/Select.fixture.tsx
@@ -94,6 +94,12 @@ export default {
       Select Example
     </Select>
   ),
+  StickyLabel: (
+    <Select label="StickyLabel Select" items={items}
+      showTopPlaceholder placeholder='POPS'
+    >
+    </Select>
+  ),
   Multiselect: (
     <Select style={{ width: 250 }} label="Multiselect" items={items} multiselect>
       Select Example

--- a/packages/ui-kit/src/Select/fixtures/Select.fixture.tsx
+++ b/packages/ui-kit/src/Select/fixtures/Select.fixture.tsx
@@ -94,9 +94,9 @@ export default {
       Select Example
     </Select>
   ),
-  StickyLabel: (
-    <Select label="StickyLabel Select" items={items}
-      showTopPlaceholder placeholder='POPS'
+  TopPlaceholder: (
+    <Select label="Animated placeholder" items={items}
+      showTopPlaceholder placeholder='i`m placeholder'
     >
     </Select>
   ),

--- a/packages/ui-kit/src/Select/index.tsx
+++ b/packages/ui-kit/src/Select/index.tsx
@@ -65,6 +65,7 @@ export interface SelectProps {
   onSelect?: (selection: SelectItemType | SelectItemType[] | null | undefined) => void;
   onClose?: (selection: SelectItemType | SelectItemType[] | null | undefined) => void;
   onReset?: () => void;
+  showTopPlaceholder?: boolean;
 }
 
 export const Select = forwardRef(
@@ -90,6 +91,7 @@ export const Select = forwardRef(
       onSelect,
       onClose,
       onReset,
+      showTopPlaceholder,
       ...props
     },
     ref,
@@ -271,6 +273,9 @@ export const Select = forwardRef(
           reset={resetFunc}
           multiselect={multiselect}
           withResetButton={withResetButton}
+          classes={classes?.button}
+          showTopPlaceholder={showTopPlaceholder}
+          placeholder={placeholder}
         >
           {children}
         </SelectButton>


### PR DESCRIPTION
Placeholder property is now working for select but previous versions should still work 
![image](https://user-images.githubusercontent.com/50058726/196511975-c809a332-a828-49e8-9383-9ca4518577ab.png)
![image](https://user-images.githubusercontent.com/50058726/196512046-6f33bd89-da8b-4c75-b0af-b32177ae4266.png)
```jsx
<Select 
  label="Animated placeholder" 
  items={items}
  showTopPlaceholder placeholder='i`m placeholder'
>
</Select>
```