### PR TITLE
feat(build): 12977 - separate ts config to tsconfig.build.json and ts…

### DIFF
--- a/packages/default-icons/tsconfig.build.json
+++ b/packages/default-icons/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "./**/*.test.ts", "./**/*.test.tsx", "./**/*.fixture.tsx", "./**/fixture/*.*"]
+}

--- a/packages/default-icons/tsconfig.json
+++ b/packages/default-icons/tsconfig.json
@@ -10,5 +10,5 @@
     "outDir": "./tslib"
   },
   "include": ["./../../global.d.ts", "./src/**/*.ts", "./src/**/*.tsx"],
-  "exclude": ["node_modules", "./**/*.test.ts","./**/*.test.tsx", "./**/*.fixture.tsx", "./**/fixture/*.*"]
+  "exclude": ["node_modules"]
 }

--- a/packages/default-theme/tsconfig.build.json
+++ b/packages/default-theme/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "./**/*.test.ts", "./**/*.test.tsx", "./**/*.fixture.tsx", "./**/fixture/*.*"]
+}

--- a/packages/default-theme/tsconfig.json
+++ b/packages/default-theme/tsconfig.json
@@ -10,5 +10,5 @@
     "outDir": "tslib"
   },
   "include": ["./../../global.d.ts", "./src/**/*.ts", "./src/**/*.tsx"],
-  "exclude": ["node_modules", "./**/*.test.ts","./**/*.test.tsx", "./**/*.fixture.tsx", "./**/fixture/*.*"]
+  "exclude": ["node_modules"]
 }

--- a/packages/ui-kit/tsconfig.build.json
+++ b/packages/ui-kit/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "./**/*.test.ts", "./**/*.test.tsx", "./**/*.fixture.tsx", "./**/fixture/*.*"]
+}

--- a/packages/ui-kit/tsconfig.json
+++ b/packages/ui-kit/tsconfig.json
@@ -9,6 +9,6 @@
     "declarationMap": true,
     "outDir": "./tslib"
   },
-  "include": ["./../../global.d.ts", "./src/**/*.ts", "./src/**/*.tsx", "./**/*.fixture.tsx", "./**/fixture/*.*"],
-  "exclude": ["node_modules", "./**/*.test.ts", "./**/*.test.tsx"]
+  "include": ["./../../global.d.ts", "./src/**/*.ts", "./src/**/*.tsx"],
+  "exclude": ["node_modules"]
 }

--- a/setup-references.mjs
+++ b/setup-references.mjs
@@ -20,14 +20,18 @@ async function getTopology() {
 }
 
 async function takeOnlyTypescriptPackages(packages) {
-  const tsConfigs = await Promise.allSettled(packages.map((pkg) => access(`${pkg}/tsconfig.json`, constants.R_OK)));
+  const tsConfigs = await Promise.allSettled(
+    packages.map((pkg) => access(`${pkg}/tsconfig.build.json`, constants.R_OK)),
+  );
   return packages.filter((_, idx) => tsConfigs[idx].status === 'fulfilled');
 }
 
 function createTsConfigWithReferences(packages) {
   return {
     files: [],
-    references: packages.map((pkg) => ({ path: pkg.replace(`${CONFIG.packagesFolder}/`, '') })),
+    references: packages.map((pkg) => ({
+      path: pkg.replace(`${CONFIG.packagesFolder}/`, '') + '/tsconfig.build.json',
+    })),
     compilerOptions: {
       composite: true,
     },

--- a/setup-references.mjs
+++ b/setup-references.mjs
@@ -30,7 +30,7 @@ function createTsConfigWithReferences(packages) {
   return {
     files: [],
     references: packages.map((pkg) => ({
-      path: pkg.replace(`${CONFIG.packagesFolder}/`, '') + '/tsconfig.build.json',
+      path: path.resolve(pkg.replace(`${CONFIG.packagesFolder}/`, ''), 'tsconfig.build.json'),
     })),
     compilerOptions: {
       composite: true,


### PR DESCRIPTION
…config.json

We wanted to have ts hints in fixtures, but we don't need fixtures in the bundle. It's a way of how to do it. tsconfig.json - includes all files (with fixtures) tsconfig.build.json - excludes fixtures

https://kontur.fibery.io/Tasks/Task/UI-Kit-Surge-preview-silent-fail-12977