### PR TITLE
feat(ui-kit: panel): 12482 - implement panel short content and its controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18891,7 +18891,7 @@
     },
     "packages/ui-kit": {
       "name": "@konturio/ui-kit",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "dependencies": {
         "downshift": "^6.1.7",
         "nanoid": "^4.0.0",

--- a/packages/ui-kit/src/Panel/Panel.fixture.tsx
+++ b/packages/ui-kit/src/Panel/Panel.fixture.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { Panel, ShortStateListenersType } from '.';
+import { Panel } from '.';
+import type {ShortStateListenersType} from '.';
 
-export default function fixture() {
+export default function Fixture() {
   const [isOpen, setIsOpen] = useState(false)
   const [isShortStateOpen, setIsShortStateOpen] = useState(false)
 

--- a/packages/ui-kit/src/Panel/Panel.fixture.tsx
+++ b/packages/ui-kit/src/Panel/Panel.fixture.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Panel } from '.';
-import type {ShortStateListenersType} from '.';
+import type { ShortStateListenersType } from '.';
 
 export default function Fixture() {
   const [isOpen, setIsOpen] = useState(false)
@@ -51,11 +51,11 @@ export default function Fixture() {
         </div>
       </Panel>
 
-      <Panel header="Short state" resize='vertical' minContentHeightPx={60}
+      <Panel header="With short state" resize='vertical' minContentHeightPx={60}
 
         isOpen={isOpen}
 
-        shortStateContent={<>WIth short state</>}
+        shortStateContent={<div style={{ margin: 'auto', padding: '2em' }}>Short state</div>}
         isShortStateOpen={isShortStateOpen}
         shortStateListeners={shortStateListeners}
         style={{ width: '200px', height: '100%' }}

--- a/packages/ui-kit/src/Panel/Panel.fixture.tsx
+++ b/packages/ui-kit/src/Panel/Panel.fixture.tsx
@@ -22,7 +22,7 @@ export default function Fixture() {
   }
 
   return (
-    <div style={{ display: 'flex', gap: '1em', flexDirection: 'row', flexWrap: 'wrap' }}>
+    <div style={{ display: 'flex', gap: '1em', flexDirection: 'row', flexWrap: 'wrap', paddingBottom: '40px' }}>
 
       <Panel header={<div style={{ fontSize: '1.2em', whiteSpace: 'pre' }}>Custom title</div>} onHeaderClick={console.log}>
         <div style={{ height: '400px', display: 'flex', margin: 'auto' }}>
@@ -58,7 +58,7 @@ export default function Fixture() {
         shortStateContent={<div style={{ margin: 'auto', padding: '2em' }}>Short state</div>}
         isShortStateOpen={isShortStateOpen}
         shortStateListeners={shortStateListeners}
-        style={{ width: '200px', height: '100%' }}
+        style={{ width: '200px' }}
 
       >
         <div style={{ display: 'flex', margin: 'auto' }}>

--- a/packages/ui-kit/src/Panel/Panel.fixture.tsx
+++ b/packages/ui-kit/src/Panel/Panel.fixture.tsx
@@ -24,7 +24,13 @@ export default function Fixture() {
   return (
     <div style={{ display: 'flex', gap: '1em', flexDirection: 'row', flexWrap: 'wrap', paddingBottom: '40px' }}>
 
-      <Panel header={<div style={{ fontSize: '1.2em', whiteSpace: 'pre' }}>Custom title</div>} onHeaderClick={console.log}>
+      <Panel
+        header={
+          <div style={{ fontSize: '1.2em', whiteSpace: 'pre' }}>
+            Custom title
+          </div>}
+        onHeaderClick={console.log}
+      >
         <div style={{ height: '400px', display: 'flex', margin: 'auto' }}>
           <div style={{ margin: 'auto', padding: '1em' }}>Content</div>
         </div>
@@ -55,7 +61,9 @@ export default function Fixture() {
 
         isOpen={isOpen}
 
-        shortStateContent={<div style={{ margin: 'auto', padding: '2em' }}>Short state</div>}
+        shortStateContent={
+          <div style={{ margin: 'auto', padding: '2em' }}>Short state</div>
+        }
         isShortStateOpen={isShortStateOpen}
         shortStateListeners={shortStateListeners}
         style={{ width: '200px' }}

--- a/packages/ui-kit/src/Panel/Panel.fixture.tsx
+++ b/packages/ui-kit/src/Panel/Panel.fixture.tsx
@@ -1,32 +1,73 @@
-import { Panel } from '.';
+import { useState } from 'react';
+import { Panel, ShortStateListenersType } from '.';
 
-export default (
-  <div style={{ display: 'flex', gap: '1em', flexDirection: 'row', flexWrap: 'wrap' }}>
-    <Panel header={<div style={{ fontSize: '1.2em', whiteSpace: 'pre' }}>Custom title</div>} onHeaderClick={console.log}>
-      <div style={{ height: '400px', display: 'flex', margin: 'auto' }}>
-        <div style={{ margin: 'auto', padding: '1em' }}>Content</div>
-      </div>
-    </Panel>
-    <Panel
-      header="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
-      onHeaderClick={console.log}
-    >
-      <div style={{ height: '400px', display: 'flex', margin: 'auto' }}>
-        <div style={{ margin: 'auto', padding: '1em' }}>Content</div>
-      </div>
-    </Panel>
-    <div>
-      <Panel header="Without close button">
-        <div style={{ display: 'flex', margin: 'auto' }}>
+export default function fixture() {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isShortStateOpen, setIsShortStateOpen] = useState(false)
+
+  const shortStateListeners: ShortStateListenersType = {
+    onClose: () => {
+      setIsOpen(false)
+      setIsShortStateOpen(false)
+    },
+    onFullStateOpen: () => {
+      setIsOpen(true)
+      setIsShortStateOpen(false)
+    },
+    onShortStateOpen: () => {
+      setIsOpen(true)
+      setIsShortStateOpen(true)
+    },
+  }
+
+  return (
+    <div style={{ display: 'flex', gap: '1em', flexDirection: 'row', flexWrap: 'wrap' }}>
+
+      <Panel header={<div style={{ fontSize: '1.2em', whiteSpace: 'pre' }}>Custom title</div>} onHeaderClick={console.log}>
+        <div style={{ height: '400px', display: 'flex', margin: 'auto' }}>
           <div style={{ margin: 'auto', padding: '1em' }}>Content</div>
         </div>
       </Panel>
-    </div>
-    
-    <Panel header="Resizable panel" resize='vertical' minContentHeightPx={40}>
-      <div style={{ display: 'flex', margin: 'auto' }}>
-        <div style={{ margin: 'auto', padding: '2em' }}>Content</div>
+      <Panel
+        header="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+        onHeaderClick={console.log}
+      >
+        <div style={{ height: '400px', display: 'flex', margin: 'auto' }}>
+          <div style={{ margin: 'auto', padding: '1em' }}>Content</div>
+        </div>
+      </Panel>
+      <div>
+        <Panel header="Without close button">
+          <div style={{ display: 'flex', margin: 'auto' }}>
+            <div style={{ margin: 'auto', padding: '1em' }}>Content</div>
+          </div>
+        </Panel>
       </div>
-    </Panel>
-  </div>
-);
+
+      <Panel header="Resizable panel" resize='vertical' minContentHeightPx={40}>
+        <div style={{ display: 'flex', margin: 'auto' }}>
+          <div style={{ margin: 'auto', padding: '2em' }}>Content</div>
+        </div>
+      </Panel>
+
+      <Panel header="Short state" resize='vertical' minContentHeightPx={60}
+
+        isOpen={isOpen}
+
+        shortStateContent={<>WIth short state</>}
+        isShortStateOpen={isShortStateOpen}
+        shortStateListeners={shortStateListeners}
+        style={{ width: '200px', height: '100%' }}
+
+      >
+        <div style={{ display: 'flex', margin: 'auto' }}>
+          <div style={{ margin: 'auto', padding: '2em' }}>
+            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Soluta mollitia aut dignissimos dolorem doloremque eos unde eveniet veritatis modi in et dolor, quia expedita sequi eius, optio animi, sunt blanditiis!
+            <br />
+          </div>
+        </div>
+      </Panel>
+    </div>
+  );
+
+}

--- a/packages/ui-kit/src/Panel/index.tsx
+++ b/packages/ui-kit/src/Panel/index.tsx
@@ -1,17 +1,31 @@
 import { Card } from '../Card';
 import cn from 'clsx';
 import s from './style.module.css';
-import { ReactElement, useMemo } from 'react';
+import type { ReactElement } from 'react';
+import { useMemo } from 'react';
 import { Text } from '../Text';
-import { ChevronDown24, ChevronUp24, DoubleChevronDown24, DoubleChevronUp24 } from '@konturio/default-icons';
+import {
+  ChevronDown24,
+  ChevronUp24,
+  DoubleChevronDown24,
+  DoubleChevronUp24
+} from '@konturio/default-icons';
 import { Modal } from '../Modal';
 
 export type ShortStateListenersType = {
-  onClose: React.MouseEventHandler<HTMLButtonElement | HTMLDivElement>
-  onFullStateOpen: React.MouseEventHandler<HTMLButtonElement | HTMLDivElement>
-  onShortStateOpen: React.MouseEventHandler<HTMLButtonElement | HTMLDivElement>
+  onClose: React.MouseEventHandler<
+    HTMLButtonElement | HTMLDivElement
+  >
+  onFullStateOpen: React.MouseEventHandler<
+    HTMLButtonElement | HTMLDivElement
+  >
+  onShortStateOpen: React.MouseEventHandler<
+    HTMLButtonElement | HTMLDivElement
+  >
 }
-interface Panel extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+interface Panel extends React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLDivElement>, HTMLDivElement
+> { 
   className?: string;
   header?: string | React.ReactElement | React.ReactElement[];
   headerIcon?: ReactElement;
@@ -83,7 +97,8 @@ export function Panel({
   function panelContent() {
     let content: React.ReactNode | null = null
 
-    if (isShortStateOpen && shortStateContent && isOpen) content = shortStateContent
+    if (isShortStateOpen && shortStateContent && isOpen)
+      content = shortStateContent
     else if (isOpen) content = children
 
     if (content) return (

--- a/packages/ui-kit/src/Panel/index.tsx
+++ b/packages/ui-kit/src/Panel/index.tsx
@@ -1,7 +1,7 @@
 import { Card } from '../Card';
 import cn from 'clsx';
 import s from './style.module.css';
-import type { ReactElement } from 'react';
+import { ReactElement, useMemo } from 'react';
 import { Text } from '../Text';
 import { ChevronDown24, ChevronUp24, DoubleChevronDown24, DoubleChevronUp24 } from '@konturio/default-icons';
 import { Modal } from '../Modal';
@@ -76,26 +76,27 @@ export function Panel({
   ...rest
 }: React.PropsWithChildren<Panel>) {
 
+  const panelStyles = useMemo(() => {
+    return { minHeight: minContentHeightPx || 'unset', resize }
+  }, [minContentHeightPx, resize])
+
   function panelContent() {
-    if (isShortStateOpen && shortStateContent && isOpen) return (
+    let content: React.ReactNode | null = null
+
+    if (isShortStateOpen && shortStateContent && isOpen) content = shortStateContent
+    else if (isOpen) content = children
+
+    if (content) return (
       <div
         className={cn(s.contentContainer, contentClassName)}
         ref={contentContainerRef}
-        style={{ minHeight: minContentHeightPx || 'unset', resize: resize }}
+        style={panelStyles}
       >
-        {shortStateContent}
+        {content}
       </div>
     );
 
-    if (isOpen) return (<div
-      className={cn(s.contentContainer, contentClassName)}
-      ref={contentContainerRef}
-      style={{ minHeight: minContentHeightPx || 'unset', resize: resize }}
-    >
-      {children}
-    </div>)
-
-    return null;
+    return null
   }
 
   function headerControls() {

--- a/packages/ui-kit/src/Panel/index.tsx
+++ b/packages/ui-kit/src/Panel/index.tsx
@@ -1,18 +1,23 @@
 import { Card } from '../Card';
 import cn from 'clsx';
 import s from './style.module.css';
-import type { ReactChild } from 'react';
+import type { ReactElement } from 'react';
 import { Text } from '../Text';
-import { ChevronDown24, ChevronUp24 } from '@konturio/default-icons';
+import { ChevronDown24, ChevronUp24, DoubleChevronDown24, DoubleChevronUp24 } from '@konturio/default-icons';
 import { Modal } from '../Modal';
 
+export type ShortStateListenersType = {
+  onClose: React.MouseEventHandler<HTMLButtonElement | HTMLDivElement>
+  onFullStateOpen: React.MouseEventHandler<HTMLButtonElement | HTMLDivElement>
+  onShortStateOpen: React.MouseEventHandler<HTMLButtonElement | HTMLDivElement>
+}
 interface Panel extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
   className?: string;
-  header?: string | React.ReactChild | React.ReactChild[];
-  headerIcon?: React.ReactChild;
+  header?: string | React.ReactElement | React.ReactElement[];
+  headerIcon?: ReactElement;
   isOpen?: boolean;
   onHeaderClick?: React.MouseEventHandler<HTMLDivElement>;
-  customCloseBtn?: ReactChild;
+  customCloseBtn?: ReactElement;
   classes?: {
     header?: string;
     headerTitle?: string;
@@ -26,7 +31,28 @@ interface Panel extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElem
   minContentHeightPx?: number;
   contentContainerRef?: (node: HTMLDivElement) => void;
   contentClassName?: string;
-  resize?: 'vertical' | 'horizontal' | 'both' | 'none'
+  resize?: 'vertical' | 'horizontal' | 'both' | 'none';
+  /**
+   * Optional JSX content of panels short state.
+   * Creates short state of the panel.
+   * 
+   * when used:
+   * @param isShortStateOpen - required to show the short state
+   * @param shortStateListeners - required to handle clicks on panel icons
+   */
+  shortStateContent?: ReactElement;
+  /**
+   * @param isOpen must also be `true` to display short state content
+   */
+  isShortStateOpen?: boolean;
+  /**
+   * you can import `ShortStateListenersType` to conveniently describe this propert
+   */
+  shortStateListeners?: {
+    onClose: React.MouseEventHandler<HTMLButtonElement | HTMLDivElement>
+    onFullStateOpen: React.MouseEventHandler<HTMLButtonElement | HTMLDivElement>
+    onShortStateOpen: React.MouseEventHandler<HTMLButtonElement | HTMLDivElement>
+  }
 }
 
 export function Panel({
@@ -44,33 +70,105 @@ export function Panel({
   contentContainerRef,
   contentClassName,
   resize = 'none',
+  shortStateContent,
+  isShortStateOpen,
+  shortStateListeners,
   ...rest
 }: React.PropsWithChildren<Panel>) {
 
-  const panel = <Card className={cn(s.card, className)} {...rest}>
-    {header && (
-      <div className={cn(onHeaderClick && s.hoverable)}>
-        <div className={cn(s.header, classes?.header)} onClick={onHeaderClick}>
-          <div className={cn(s.headerTitle, classes?.headerTitle)}>
-            {headerIcon}
-            <Text type="heading-l">{header}</Text>
-          </div>
-          {onHeaderClick && (
-            <button className={cn(s.close, classes?.closeBtn)}>
-              {customCloseBtn ? customCloseBtn
-                : isOpen ? <ChevronUp24 /> : <ChevronDown24 />}
-            </button>
-          )}
-        </div>
+  function panelContent() {
+    if (isShortStateOpen && shortStateContent && isOpen) return (
+      <div
+        className={cn(s.contentContainer, contentClassName)}
+        ref={contentContainerRef}
+        style={{ minHeight: minContentHeightPx || 'unset', resize: resize }}
+      >
+        {shortStateContent}
       </div>
-    )}
-    {isOpen && <div
+    );
+
+    if (isOpen) return (<div
       className={cn(s.contentContainer, contentClassName)}
       ref={contentContainerRef}
       style={{ minHeight: minContentHeightPx || 'unset', resize: resize }}
     >
       {children}
-    </div>}
+    </div>)
+
+    return null;
+  }
+
+  function headerControls() {
+    // Simple panel controls
+    if (!shortStateContent && !onHeaderClick) return null;
+    if (!shortStateContent) return (
+      <button className={cn(s.close, classes?.closeBtn)}>
+        {customCloseBtn ? customCloseBtn
+          : isOpen ? <ChevronUp24 /> : <ChevronDown24 />}
+      </button>
+    )
+    // Short state panel header
+    if (isOpen && isShortStateOpen) return <>
+      <button
+        className={cn(s.close, classes?.closeBtn)}
+        onClick={shortStateListeners?.onFullStateOpen}
+      >
+        <ChevronDown24 />
+      </button>
+
+      <button
+        className={cn(s.close, classes?.closeBtn)}
+        onClick={shortStateListeners?.onClose}
+      >
+        <ChevronUp24 />
+      </button>
+    </>
+    // Full state panel header
+    if (isOpen) return <>
+      <button
+        className={cn(s.close, classes?.closeBtn)}
+        onClick={shortStateListeners?.onShortStateOpen}
+      >
+        <ChevronUp24 />
+      </button>
+
+      <button
+        className={cn(s.close, classes?.closeBtn)}
+        onClick={shortStateListeners?.onClose}
+      >
+        <DoubleChevronUp24 />
+      </button>
+    </>
+    // Closed panel header
+    return <>
+      <button
+        className={cn(s.close, classes?.closeBtn)}
+        onClick={shortStateListeners?.onFullStateOpen}
+      >
+        <DoubleChevronDown24 />
+      </button>
+
+      <button
+        className={cn(s.close, classes?.closeBtn)}
+        onClick={shortStateListeners?.onShortStateOpen}
+      >
+        <ChevronDown24 />
+      </button>
+    </>
+  }
+
+  const panel = <Card className={cn(s.card, className)} {...rest}>
+    {header &&
+      (<div className={cn(onHeaderClick && s.hoverable)}>
+        <div className={cn(s.header, classes?.header)} onClick={onHeaderClick}>
+          <div className={cn(s.headerTitle, classes?.headerTitle)}>
+            {headerIcon}
+            <Text type="heading-l">{header}</Text>
+          </div>
+          {headerControls()}
+        </div>
+      </div>)}
+    {panelContent()}
   </Card>
 
 
@@ -87,7 +185,7 @@ export function Panel({
 }
 
 interface PanelIconProps {
-  icon: ReactChild;
+  icon: ReactElement;
   clickHandler?: () => void;
   className?: string;
 }

--- a/packages/ui-kit/src/Panel/index.tsx
+++ b/packages/ui-kit/src/Panel/index.tsx
@@ -111,16 +111,16 @@ export function Panel({
     if (isOpen && isShortStateOpen) return <>
       <button
         className={cn(s.close, classes?.closeBtn)}
-        onClick={shortStateListeners?.onFullStateOpen}
+        onClick={shortStateListeners?.onClose}
       >
-        <ChevronDown24 />
+        <ChevronUp24 />
       </button>
 
       <button
         className={cn(s.close, classes?.closeBtn)}
-        onClick={shortStateListeners?.onClose}
+        onClick={shortStateListeners?.onFullStateOpen}
       >
-        <ChevronUp24 />
+        <ChevronDown24 />
       </button>
     </>
     // Full state panel header

--- a/packages/ui-kit/src/Panel/style.module.css
+++ b/packages/ui-kit/src/Panel/style.module.css
@@ -1,3 +1,7 @@
+.card{
+  height: 100%;
+}
+
 .header {
   padding: var(--unit) var(--double-unit);
   display: flex;


### PR DESCRIPTION
Short state option was implemented according to design (i switched 2 red icons so that it would make sense)
![image](https://user-images.githubusercontent.com/50058726/202923625-2abfc40a-6ff8-4faa-b238-93effe769cf7.png)

This is supposed to be backwards compitable and not break any previous panels
Feel free to comment if the interfaces is okay to you or you want different approach (different callback system) or naming! 

I kept panel state control outside of component.