### PR TITLE
ref(ui-kit: panel): make panel stateless again

### DIFF
--- a/packages/default-theme/variables.css
+++ b/packages/default-theme/variables.css
@@ -125,6 +125,7 @@
   --border-radius: 4px;
   --half-border-radius: 2px;
   --quarter-border-radius: 1px;
+  --short-link-width: 192px;
 
   /* Animations */
   --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);

--- a/packages/ui-kit/src/Panel/Panel.fixture.tsx
+++ b/packages/ui-kit/src/Panel/Panel.fixture.tsx
@@ -1,25 +1,49 @@
-import { useState } from 'react';
+import { ChevronDown24, ChevronUp24, DoubleChevronDown24, DoubleChevronUp24 } from '@konturio/default-icons';
+import { useEffect, useState } from 'react';
+import type { PanelCustomControl } from '.';
 import { Panel } from '.';
-import type { ShortStateListenersType } from '.';
 
 export default function Fixture() {
-  const [isOpen, setIsOpen] = useState(false)
-  const [isShortStateOpen, setIsShortStateOpen] = useState(false)
-
-  const shortStateListeners: ShortStateListenersType = {
-    onClose: () => {
-      setIsOpen(false)
-      setIsShortStateOpen(false)
-    },
-    onFullStateOpen: () => {
-      setIsOpen(true)
-      setIsShortStateOpen(false)
-    },
-    onShortStateOpen: () => {
-      setIsOpen(true)
-      setIsShortStateOpen(true)
-    },
+  // This whole thing can be wrapped into custom hook
+  const [panelState, setPanelState] = useState<'full' | 'short' | 'closed'>('full')
+  const openFullControl: PanelCustomControl = {
+    icon: <DoubleChevronDown24 />,
+    onWrapperClick: () => setPanelState('full') 
   }
+  const openHalfwayControl: PanelCustomControl = {
+    icon: <ChevronDown24 />,
+    onWrapperClick: () => setPanelState(prevState => prevState === 'closed' ? 'short' : 'full') 
+  }
+  const closeHalfwayControl: PanelCustomControl = {
+    icon: <ChevronUp24 />,
+    onWrapperClick: () => setPanelState(prevState => prevState === 'full' ? 'short' : 'closed') 
+  }
+  const closeControl: PanelCustomControl = {
+    icon: <DoubleChevronUp24 />,
+    onWrapperClick: () => setPanelState('closed') 
+  }
+  const [panelControls, setPanelControls] = useState<PanelCustomControl[]>([])
+
+  useEffect(() => {
+    panelState === 'full' && setPanelControls([closeHalfwayControl, closeControl])
+    panelState === 'short' && setPanelControls([closeHalfwayControl, openHalfwayControl])
+    panelState === 'closed' && setPanelControls([openFullControl, openHalfwayControl])
+  }, [panelState])
+  
+
+
+  const panelContent = {
+    full:
+      <div style={{ display: 'flex', margin: 'auto' }}>
+        <div style={{ margin: 'auto', padding: '2em' }}>
+          Lorem ipsum dolor sit, amet consectetur adipisicing elit. Soluta mollitia aut dignissimos dolorem doloremque eos unde eveniet veritatis modi in et dolor, quia expedita sequi eius, optio animi, sunt blanditiis!
+          <br />
+        </div>
+      </div>,
+    short: <div style={{ margin: 'auto', padding: '2em' }}>Short state</div>,
+    closed: null
+  }
+
 
   return (
     <div style={{ display: 'flex', gap: '1em', flexDirection: 'row', flexWrap: 'wrap', paddingBottom: '40px' }}>
@@ -57,24 +81,13 @@ export default function Fixture() {
         </div>
       </Panel>
 
-      <Panel header="With short state" resize='vertical' minContentHeight={60}
-
-        isOpen={isOpen}
-
-        shortStateContent={
-          <div style={{ margin: 'auto', padding: '2em' }}>Short state</div>
-        }
-        isShortStateOpen={isShortStateOpen}
-        shortStateListeners={shortStateListeners}
+      <Panel
+        header={`With short state. Current state: ${panelState}`} resize='vertical' minContentHeight={60}
+        isOpen={panelState !== 'closed'}
         style={{ width: '200px' }}
-
+        customControls={panelControls}
       >
-        <div style={{ display: 'flex', margin: 'auto' }}>
-          <div style={{ margin: 'auto', padding: '2em' }}>
-            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Soluta mollitia aut dignissimos dolorem doloremque eos unde eveniet veritatis modi in et dolor, quia expedita sequi eius, optio animi, sunt blanditiis!
-            <br />
-          </div>
-        </div>
+        {panelContent[panelState]}
       </Panel>
     </div>
   );

--- a/packages/ui-kit/src/Panel/index.tsx
+++ b/packages/ui-kit/src/Panel/index.tsx
@@ -1,33 +1,19 @@
 import { Card } from '../Card';
 import cn from 'clsx';
 import s from './style.module.css';
-import type { ReactElement } from 'react';
-import { useMemo } from 'react';
+import type { MouseEventHandler, ReactElement } from 'react';
 import { Text } from '../Text';
-import {
-  ChevronDown24,
-  ChevronUp24,
-  DoubleChevronDown24,
-  DoubleChevronUp24
-} from '@konturio/default-icons';
+import { ChevronDown24, ChevronUp24 } from '@konturio/default-icons';
 import { Modal } from '../Modal';
+import { nanoid } from 'nanoid';
 
-export type ShortStateListenersType = {
-  onClose: React.MouseEventHandler<
-    HTMLButtonElement | HTMLDivElement
-  >
-  onFullStateOpen: React.MouseEventHandler<
-    HTMLButtonElement | HTMLDivElement
-  >
-  onShortStateOpen: React.MouseEventHandler<
-    HTMLButtonElement | HTMLDivElement
-  >
+export type PanelCustomControl = {
+  icon: ReactElement;
+  onWrapperClick: MouseEventHandler<HTMLButtonElement>
 }
-interface Panel extends React.DetailedHTMLProps<
-  React.HTMLAttributes<HTMLDivElement>, HTMLDivElement
-> { 
+interface Panel extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
   className?: string;
-  header?: string | React.ReactElement | React.ReactElement[];
+  header?: string | ReactElement | ReactElement[];
   headerIcon?: ReactElement;
   isOpen?: boolean;
   onHeaderClick?: React.MouseEventHandler<HTMLDivElement>;
@@ -42,31 +28,12 @@ interface Panel extends React.DetailedHTMLProps<
     onModalClick: () => void
     showInModal: boolean;
   };
+  contentHeight?: number | string;
   minContentHeight?: number | string;
   contentContainerRef?: (node: HTMLDivElement) => void;
   contentClassName?: string;
   resize?: 'vertical' | 'horizontal' | 'both' | 'none';
-  /**
-   * Optional JSX content of panels short state.
-   * Creates short state of the panel.
-   * 
-   * when used:
-   * @param isShortStateOpen - required to show the short state
-   * @param shortStateListeners - required to handle clicks on panel icons
-   */
-  shortStateContent?: ReactElement;
-  /**
-   * @param isOpen must also be `true` to display short state content
-   */
-  isShortStateOpen?: boolean;
-  /**
-   * you can import `ShortStateListenersType` to conveniently describe this propert
-   */
-  shortStateListeners?: {
-    onClose: React.MouseEventHandler<HTMLButtonElement | HTMLDivElement>
-    onFullStateOpen: React.MouseEventHandler<HTMLButtonElement | HTMLDivElement>
-    onShortStateOpen: React.MouseEventHandler<HTMLButtonElement | HTMLDivElement>
-  }
+  customControls?: PanelCustomControl[];
 }
 
 export function Panel({
@@ -80,111 +47,52 @@ export function Panel({
   ref,
   isOpen = true,
   modal,
+  contentHeight,
   minContentHeight,
   contentContainerRef,
   contentClassName,
+  customControls,
   resize = 'none',
-  shortStateContent,
-  isShortStateOpen,
-  shortStateListeners,
   ...rest
 }: React.PropsWithChildren<Panel>) {
 
-  const panelStyles = useMemo(() => {
-    return { minHeight: minContentHeight || 'unset', resize }
-  }, [minContentHeight, resize])
-
-  function panelContent() {
-    let content: React.ReactNode | null = null
-
-    if (isShortStateOpen && shortStateContent && isOpen)
-      content = shortStateContent
-    else if (isOpen) content = children
-
-    if (content) return (
-      <div
-        className={cn(s.contentContainer, contentClassName)}
-        ref={contentContainerRef}
-        style={panelStyles}
-      >
-        {content}
-      </div>
-    );
-
-    return null
-  }
-
-  function headerControls() {
-    // Simple panel controls
-    if (!shortStateContent && !onHeaderClick) return null;
-    if (!shortStateContent) return (
-      <button className={cn(s.close, classes?.closeBtn)}>
-        {customCloseBtn ? customCloseBtn
-          : isOpen ? <ChevronUp24 /> : <ChevronDown24 />}
-      </button>
-    )
-    // Short state panel header
-    if (isOpen && isShortStateOpen) return <>
-      <button
-        className={cn(s.close, classes?.closeBtn)}
-        onClick={shortStateListeners?.onClose}
-      >
-        <ChevronUp24 />
-      </button>
-
-      <button
-        className={cn(s.close, classes?.closeBtn)}
-        onClick={shortStateListeners?.onFullStateOpen}
-      >
-        <ChevronDown24 />
-      </button>
-    </>
-    // Full state panel header
-    if (isOpen) return <>
-      <button
-        className={cn(s.close, classes?.closeBtn)}
-        onClick={shortStateListeners?.onShortStateOpen}
-      >
-        <ChevronUp24 />
-      </button>
-
-      <button
-        className={cn(s.close, classes?.closeBtn)}
-        onClick={shortStateListeners?.onClose}
-      >
-        <DoubleChevronUp24 />
-      </button>
-    </>
-    // Closed panel header
-    return <>
-      <button
-        className={cn(s.close, classes?.closeBtn)}
-        onClick={shortStateListeners?.onFullStateOpen}
-      >
-        <DoubleChevronDown24 />
-      </button>
-
-      <button
-        className={cn(s.close, classes?.closeBtn)}
-        onClick={shortStateListeners?.onShortStateOpen}
-      >
-        <ChevronDown24 />
-      </button>
-    </>
-  }
-
   const panel = <Card className={cn(s.card, className)} {...rest}>
-    {header &&
-      (<div className={cn(onHeaderClick && s.hoverable)}>
-        <div className={cn(s.header, classes?.header)} onClick={onHeaderClick}>
-          <div className={cn(s.headerTitle, classes?.headerTitle)}>
-            {headerIcon}
-            <Text type="heading-l">{header}</Text>
-          </div>
-          {headerControls()}
+    {header && <div className={cn(onHeaderClick && s.hoverable)}>
+      <div className={cn(s.header, classes?.header)} onClick={onHeaderClick}>
+        <div className={cn(s.headerTitle, classes?.headerTitle)}>
+          {headerIcon}
+          <Text type="heading-l">{header}</Text>
         </div>
-      </div>)}
-    {panelContent()}
+        {/* backwards compatibility */}
+        {!customControls && onHeaderClick && (
+          <button className={cn(s.close, classes?.closeBtn)}>
+            {isOpen ? <ChevronUp24 /> : <ChevronDown24 />}
+          </button>
+        )}
+
+        {customControls?.map(control => (
+          <button
+            className={cn(s.close, classes?.closeBtn)}
+            onClick={control.onWrapperClick}
+            key={nanoid(4)}
+          >
+            {control.icon}
+          </button>
+        ))}
+      </div>
+    </div>
+    }
+    {isOpen && <div
+      className={cn(s.contentContainer, contentClassName)}
+      ref={contentContainerRef}
+      style={{
+        resize: resize,
+        height: contentHeight || 'unset',
+        minHeight: minContentHeight || 'unset'
+      }}
+    >
+      {children}
+    </div>}
   </Card>
 
 

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -15,6 +15,7 @@ export { Details } from './Details';
 export { Logo } from './Logo';
 export { Button } from './Button';
 export { Panel, PanelIcon } from './Panel';
+export type { PanelCustomControl } from './Panel'
 export { Radio } from './Radio';
 export { Textarea } from './Textarea'
 export { Toggler } from './Toggler';


### PR DESCRIPTION
Short stated was moved out from component - now it has custom controls that can help implement short state, but keep component stateless

added export of helper type for panel custom control `PanelCustomControl`
added `short-link-width` css variable as I'll forget to add it otherwise