### PR TITLE
feat(ui-kit:-timeline): 13937-add-configuration-for-timline-paddings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,8 @@
   },
   "extends": [
     "plugin:@typescript-eslint/recommended",
-    "plugin:react/recommended"
+    "plugin:react/recommended",
+    "plugin:prettier/recommended"
   ],
   "parserOptions": {
     "ecmaVersion": 2020,
@@ -21,6 +22,7 @@
     }
   },
   "rules": {
+    "prettier/prettier": "warn",
     "import/order": [
       "warn",
       {

--- a/cosmos/cosmos.userdeps.js
+++ b/cosmos/cosmos.userdeps.js
@@ -33,12 +33,13 @@ import fixture22 from './../packages/ui-kit/src/Selector/Selector.fixture.tsx';
 import fixture23 from './../packages/ui-kit/src/Tabs/fixtures/Tabs.fixture.tsx';
 import fixture24 from './../packages/ui-kit/src/Text/Text.fixture.tsx';
 import fixture25 from './../packages/ui-kit/src/Textarea/Textarea.fixture.tsx';
-import fixture26 from './../packages/ui-kit/src/Timeline/fixture/CustomTemplate.fixture.tsx';
-import fixture27 from './../packages/ui-kit/src/Timeline/fixture/ImperativeApi.fixture.tsx';
-import fixture28 from './../packages/ui-kit/src/Timeline/fixture/Timeline.fixture.tsx';
-import fixture29 from './../packages/ui-kit/src/Timeline/fixture/TimeLineWithDropDown.fixture.tsx';
-import fixture30 from './../packages/ui-kit/src/TimeSlider/TimeSlider.fixture.tsx';
-import fixture31 from './../packages/ui-kit/src/Toggler/Toggler.fixture.tsx';
+import fixture26 from './../packages/ui-kit/src/Timeline/fixture/ChangeMargins.fixture.tsx';
+import fixture27 from './../packages/ui-kit/src/Timeline/fixture/CustomTemplate.fixture.tsx';
+import fixture28 from './../packages/ui-kit/src/Timeline/fixture/ImperativeApi.fixture.tsx';
+import fixture29 from './../packages/ui-kit/src/Timeline/fixture/Timeline.fixture.tsx';
+import fixture30 from './../packages/ui-kit/src/Timeline/fixture/TimeLineWithDropDown.fixture.tsx';
+import fixture31 from './../packages/ui-kit/src/TimeSlider/TimeSlider.fixture.tsx';
+import fixture32 from './../packages/ui-kit/src/Toggler/Toggler.fixture.tsx';
 
 import decorator0 from './../cosmos.decorator.tsx';
 import decorator1 from './../packages/ui-kit/cosmos.decorator.tsx';
@@ -74,12 +75,13 @@ export const fixtures = {
   'packages/ui-kit/src/Tabs/fixtures/Tabs.fixture.tsx': { module: { default: fixture23 } },
   'packages/ui-kit/src/Text/Text.fixture.tsx': { module: { default: fixture24 } },
   'packages/ui-kit/src/Textarea/Textarea.fixture.tsx': { module: { default: fixture25 } },
-  'packages/ui-kit/src/Timeline/fixture/CustomTemplate.fixture.tsx': { module: { default: fixture26 } },
-  'packages/ui-kit/src/Timeline/fixture/ImperativeApi.fixture.tsx': { module: { default: fixture27 } },
-  'packages/ui-kit/src/Timeline/fixture/Timeline.fixture.tsx': { module: { default: fixture28 } },
-  'packages/ui-kit/src/Timeline/fixture/TimeLineWithDropDown.fixture.tsx': { module: { default: fixture29 } },
-  'packages/ui-kit/src/TimeSlider/TimeSlider.fixture.tsx': { module: { default: fixture30 } },
-  'packages/ui-kit/src/Toggler/Toggler.fixture.tsx': { module: { default: fixture31 } }
+  'packages/ui-kit/src/Timeline/fixture/ChangeMargins.fixture.tsx': { module: { default: fixture26 } },
+  'packages/ui-kit/src/Timeline/fixture/CustomTemplate.fixture.tsx': { module: { default: fixture27 } },
+  'packages/ui-kit/src/Timeline/fixture/ImperativeApi.fixture.tsx': { module: { default: fixture28 } },
+  'packages/ui-kit/src/Timeline/fixture/Timeline.fixture.tsx': { module: { default: fixture29 } },
+  'packages/ui-kit/src/Timeline/fixture/TimeLineWithDropDown.fixture.tsx': { module: { default: fixture30 } },
+  'packages/ui-kit/src/TimeSlider/TimeSlider.fixture.tsx': { module: { default: fixture31 } },
+  'packages/ui-kit/src/Toggler/Toggler.fixture.tsx': { module: { default: fixture32 } }
 };
 
 export const decorators = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18887,11 +18887,11 @@
     },
     "packages/default-theme": {
       "name": "@konturio/default-theme",
-      "version": "3.1.0"
+      "version": "3.2.0"
     },
     "packages/ui-kit": {
       "name": "@konturio/ui-kit",
-      "version": "3.4.2",
+      "version": "3.6.2",
       "dependencies": {
         "downshift": "^6.1.7",
         "nanoid": "^4.0.0",

--- a/packages/ui-kit/src/Timeline/fixture/ChangeMargins.fixture.tsx
+++ b/packages/ui-kit/src/Timeline/fixture/ChangeMargins.fixture.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { useValue } from 'react-cosmos/fixture';
+import { Timeline } from '..';
+import testData from './testData';
+
+const episodesMap = testData.reduce(
+  (acc, i, n) => {
+    acc[n.toString()] = { id: n, ...i };
+    return acc;
+  },
+  {} as Record<
+    string,
+    {
+      name: string;
+      id: number;
+      startedAt: string;
+      endedAt: string;
+      updatedAt: string;
+    }
+  >,
+);
+
+export default {
+  ['Margins']: () => {
+    const [data] = useState(() =>
+      Object.values(episodesMap).map((d) => ({
+        id: d.id,
+        start: new Date(d.startedAt),
+        end: new Date(d.endedAt),
+      })),
+    );
+
+    const [axisMargin] = useValue('axisMargin', {
+      defaultValue: 17,
+    });
+
+    const [itemVerticalMargin] = useValue('itemVerticalMargin', {
+      defaultValue: 14,
+    });
+
+    const [itemHorizontalMargin] = useValue('itemHorizontalMargin', {
+      defaultValue: 14,
+    });
+
+    return (
+      <div style={{ minWidth: '85%', display: 'flex', flexFlow: 'column nowrap', gap: '8px' }}>
+        <div>
+          <Timeline
+            margin={{
+              axis: axisMargin,
+              item: {
+                vertical: itemVerticalMargin,
+                horizontal: itemHorizontalMargin,
+              },
+            }}
+            dataset={data}
+            cluster={false}
+            stack={true}
+            selected={[]}
+          />
+        </div>
+      </div>
+    );
+  },
+};

--- a/packages/ui-kit/src/Timeline/implementation/vis-timeline/toVisTimelineOptions.tsx
+++ b/packages/ui-kit/src/Timeline/implementation/vis-timeline/toVisTimelineOptions.tsx
@@ -12,9 +12,9 @@ export const toVisTimelineOptions = (options: TimelineOptions): VisTimelineOptio
   if (options.cluster) {
     timelineOptions.cluster = options.cluster;
     if (timelineOptions.cluster.titleTemplate === undefined) {
-      timelineOptions.cluster.titleTemplate = ''
+      timelineOptions.cluster.titleTemplate = '';
       // https://github.com/visjs/vis-timeline/issues/1543
-      // @ts-expect-error - this property added by patch package 
+      // @ts-expect-error - this property added by patch package
       timelineOptions.cluster.contentTemplate = () => '';
     }
   }
@@ -24,7 +24,11 @@ export const toVisTimelineOptions = (options: TimelineOptions): VisTimelineOptio
     timelineOptions.template = (item: unknown, el: Element, data) => {
       const wrapper = document.createElement('div');
       const root = createRoot(wrapper);
-      root.render(<div id="listener" onClick={(e) => console.log(e)}><TimelineEntryComponent {...data} isSelected={false} /></div>);
+      root.render(
+        <div id="listener" onClick={(e) => console.log(e)}>
+          <TimelineEntryComponent {...data} isSelected={false} />
+        </div>,
+      );
       return wrapper;
     };
   }
@@ -41,6 +45,10 @@ export const toVisTimelineOptions = (options: TimelineOptions): VisTimelineOptio
         return wrapper;
       },
     };
+  }
+
+  if (typeof options.margin !== 'undefined') {
+    timelineOptions.margin = options.margin;
   }
 
   return timelineOptions;

--- a/packages/ui-kit/src/Timeline/types.ts
+++ b/packages/ui-kit/src/Timeline/types.ts
@@ -1,3 +1,5 @@
+import type { TimelineOptions as VisTimelineOptions } from 'vis-timeline';
+
 export interface TimelineEntry {
   id: string | number;
   start: Date;
@@ -27,7 +29,7 @@ export type TimelineTooltipComponent = (props: {
   id: string | number;
   style?: string;
   title?: string;
-  selectable?: boolean
+  selectable?: boolean;
 }) => JSX.Element;
 
 export interface TimelineProps {
@@ -41,6 +43,7 @@ export interface TimelineProps {
   timelineEntryComponent?: TimelineEntryComponent;
   onSelect?: (item: TimelineEntry[], event: PointerEvent) => void;
   onHover?: (item: TimelineEntry[], event: PointerEvent) => void;
+  margin?: VisTimelineOptions['margin'];
 }
 
 export interface TimelineImperativeApi {


### PR DESCRIPTION
- Add `margin` prop to `Timeline` component to allow managing timeline items' margin
- Add `prettier` recommended to `eslint` conf

With default margins:
<img width="363" alt="image" src="https://user-images.githubusercontent.com/14041229/209920880-c96b650f-7e45-4892-98ff-49bea1621659.png">
With zero margins:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/14041229/209920989-a7d68bf0-c31c-4b74-8427-a13bd040f49a.png">

