### PR TITLE
feat(card) - box-shadow fix

### DIFF
--- a/packages/default-theme/variables.css
+++ b/packages/default-theme/variables.css
@@ -136,11 +136,19 @@
   --modal: 1000;
   --tooltip: 1100;
 
-  /* Shadows */
+  /* DEPRECATED - Old Theme shadow variables */
+  /* TODO: remove this section after we migrate all old variables usages to new ones */
   --elevation-1: 0 1px 2px rgba(0, 0, 0, 0.3), 0 16px 24px rgba(0, 0, 0, 0.06), 0 2px 6px rgba(0, 0, 0, 0.04),
     0 0 1px rgba(0, 0, 0, 0.04);
   --elevation-2: 0 4px 4px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.3), 0 16px 24px rgba(0, 0, 0, 0.06),
     0 2px 6px rgba(0, 0, 0, 0.04), 0 0 1px rgba(0, 0, 0, 0.04);
   --elevation-3: 0px 1px 2px rgba(0, 0, 0, 0.15), 0px 6px 12px rgba(0, 0, 0, 0.06), 0px 2px 6px rgba(0, 0, 0, 0.1),
     0px 0px 1px rgba(0, 0, 0, 0.02);
+
+  /* New shadows */
+  --shadow-small: 0px 1px 4px rgba(0, 0, 0, 0.2);
+  --shadow-medium: 0px 1px 2px rgba(0, 0, 0, 0.15), 0px 6px 8px rgba(0, 0, 0, 0.06), 0px 2px 6px rgba(0, 0, 0, 0.1),
+    0px 0px 1px rgba(0, 0, 0, 0.02);
+  --shadow-large: 0px 4px 8px rgba(0, 0, 0, 0.15), 0px 1px 2px rgba(0, 0, 0, 0.2), 0px 16px 24px rgba(0, 0, 0, 0.06),
+    0px 2px 6px rgba(0, 0, 0, 0.04);
 }

--- a/packages/ui-kit/src/Card/style.module.css
+++ b/packages/ui-kit/src/Card/style.module.css
@@ -3,7 +3,7 @@
   border-radius: var(--border-radius);
   background-color: var(--base-weak);
   position: relative;
-  box-shadow: var(--elevation-1);
+  box-shadow: var(--shadow-medium);
 }
 
 .inline {


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Fix-shadow-from-Analytics-panel-13478

solution idea - fix  box-shadow, not to change z-index to prevent affection of box-shadow.

existing box-shadow 
 0 1px 2px rgba(0, 0, 0, 0.3), 0 16px 24px rgba(0, 0, 0, 0.06), 0 2px 6px rgba(0, 0, 0, 0.04), 0 0 1px rgba(0, 0, 0, 0.04);
    
 final 
 0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 6px rgba(0, 0, 0, 0.04), 0 0 1px rgba(0, 0, 0, 0.04);
 
 so I just get rid of this section `0 16px 24px rgba(0, 0, 0, 0.06),` that affected bottom panel
 
 **Screenshots:** (pay attention on the middle panel, it's top part got darkened because of top panel shadows)
 before
<img width="955" alt="Screenshot 2023-01-16 at 16 08 40" src="https://user-images.githubusercontent.com/20676525/212685652-5b491d6f-f9bd-4eab-86bd-fa9eeddf1b5c.png">

after
<img width="974" alt="Screenshot 2023-01-16 at 15 58 24" src="https://user-images.githubusercontent.com/20676525/212683836-7249017c-8424-421f-92f9-9ffce54d45f3.png">
