### PR TITLE
fix(panel): add space fitter

### DIFF
--- a/packages/ui-kit/src/Panel/index.tsx
+++ b/packages/ui-kit/src/Panel/index.tsx
@@ -73,6 +73,8 @@ export function Panel({
               <button className={cn(s.close, classes?.closeBtn)}>{isOpen ? <ChevronUp24 /> : <ChevronDown24 />}</button>
             )}
 
+            <div style={{ flex: 1 }}></div>
+
             {customControls?.map((control) => (
               <button className={cn(s.close, classes?.closeBtn)} onClick={control.onWrapperClick} key={nanoid(4)}>
                 {control.icon}

--- a/packages/ui-kit/src/Panel/index.tsx
+++ b/packages/ui-kit/src/Panel/index.tsx
@@ -9,6 +9,8 @@ import type { MouseEventHandler, ReactElement } from 'react';
 
 export type PanelCustomControl = {
   icon: ReactElement;
+  disabled?: boolean;
+  className?: string;
   onWrapperClick: MouseEventHandler<HTMLButtonElement>;
 };
 interface Panel extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
@@ -76,7 +78,12 @@ export function Panel({
             <div style={{ flex: 1 }}></div>
 
             {customControls?.map((control) => (
-              <button className={cn(s.close, classes?.closeBtn)} onClick={control.onWrapperClick} key={nanoid(4)}>
+              <button
+                disabled={control.disabled}
+                className={cn(s.close, classes?.closeBtn, control.className)}
+                onClick={control.onWrapperClick}
+                key={nanoid(4)}
+              >
                 {control.icon}
               </button>
             ))}


### PR DESCRIPTION
add free space fitter to the panel header
add disabled and classname props to panel control interface

https://kontur.fibery.io/Tasks/Task/Replace-chevrons-(arrows)-on-panel-header-15043