### PR TITLE
fix(17879): Fix the lack of scroll in Select and MultiselectChipWithSearch

### DIFF
--- a/packages/ui-kit/src/Select/fixtures/MultiselectWithSearch.fixture.tsx
+++ b/packages/ui-kit/src/Select/fixtures/MultiselectWithSearch.fixture.tsx
@@ -11,6 +11,9 @@ const items: SelectableItem[] = [
   { title: 'Short questions and answers', value: 6 },
   { title: 'Computational Questions', value: 7 },
   { title: 'Test with an incredibly long name', value: 8 },
+  { title: 'Additional Options', value: 9 },
+  { title: 'User Prompts', value: 10 },
+  { title: 'Preferences', value: 11 },
 ];
 
 export default {

--- a/packages/ui-kit/src/Select/style.module.css
+++ b/packages/ui-kit/src/Select/style.module.css
@@ -23,6 +23,8 @@
 
   & .menu {
     position: absolute;
+    overflow-y: auto;
+    max-height: 33vh;
     z-index: 1;
     right: 0;
     list-style: none;


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-Scroll-at-layers-dropdown-is-non-operable-17879

Before:
<img width="403" alt="image" src="https://github.com/konturio/ui/assets/9570735/c4398d18-fdc5-471b-a048-2bf662db38f4">

After: 
<img width="395" alt="image" src="https://github.com/konturio/ui/assets/9570735/07b11765-ee7d-4c36-9fc5-922c17780e93">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the selection options in the Multiselect component to include 'Additional Options', 'User Prompts', and 'Preferences'.
- **Style**
	- Improved the Select component's menu with automatic overflow handling and a maximum height to enhance user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->