### PR TITLE
fix(18688): trim whitespaces in Multiselect chips content

### DIFF
--- a/packages/ui-kit/src/Select/components/SelectButton/SelectContent.tsx
+++ b/packages/ui-kit/src/Select/components/SelectButton/SelectContent.tsx
@@ -29,7 +29,7 @@ export function SelectContent<I extends SelectableItem>({
       }
       return (
         <MultiselectChip onBtnClick={() => onReset?.()} value={null}>
-          {String(children)}
+          {String(children).trim()}
         </MultiselectChip>
       );
 
@@ -43,7 +43,7 @@ export function SelectContent<I extends SelectableItem>({
         <>
           {children.map((itm, index) => (
             <MultiselectChip key={`${itm.value}_${index}`} value={itm} onBtnClick={onRemove}>
-              {itm.title}
+              {itm.title.trim()}
             </MultiselectChip>
           ))}
         </>


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-MCDA-panel-extra-whitespaces-are-present-if-there-are-no-emojis-18688