### PR TITLE
fix: select item custom class passing

### DIFF
--- a/packages/ui-kit/src/Select/components/SelectItem/index.tsx
+++ b/packages/ui-kit/src/Select/components/SelectItem/index.tsx
@@ -21,14 +21,16 @@ export const SelectItem = forwardRef(
     { className, highlighted, selected, item, title, itemProps, showSelectedIcon = true, showEntryIcon = false },
     ref,
   ) => {
-    const dynamicClasses = cn({
-      [style.selectItem]: true,
-      [style.highlighted]: !item.disabled && highlighted,
-      [style.selected]: !item.disabled && selected,
-      [style.disabled]: item.disabled,
-      [style.hasDivider]: item.hasDivider,
+    const dynamicClasses = cn(
+      {
+        [style.selectItem]: true,
+        [style.highlighted]: !item.disabled && highlighted,
+        [style.selected]: !item.disabled && selected,
+        [style.disabled]: item.disabled,
+        [style.hasDivider]: item.hasDivider,
+      },
       className,
-    });
+    );
 
     return (
       <li className={dynamicClasses} ref={ref} {...(!item.disabled ? itemProps : {})}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the readability of the `SelectItem` component's class name assignment without changing its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->