### PR TITLE
fix(MenuButton): 14063 Allow to pass popover classname as a prop. Fix passing className prop to MenuList, MenuPopover, DropdownPopover

### DIFF
--- a/packages/ui-kit/src/Dropdown/components/DropdownPopover/index.tsx
+++ b/packages/ui-kit/src/Dropdown/components/DropdownPopover/index.tsx
@@ -84,7 +84,7 @@ export const DropdownPopover = React.forwardRef(({ as: Comp = 'div', className, 
     props,
   } = useDropdownPopover({ ...rest, ref: forwardedRef });
 
-  const dynamicClasses = cn({ [style.dropdownPopover]: true, [style.hidden]: props.hidden, className });
+  const dynamicClasses = cn({ [style.dropdownPopover]: true, [style.hidden]: props.hidden }, className);
 
   return portal ? (
     <Popover {...props} className={dynamicClasses} as={Comp} targetRef={targetRef as any} position={position} />

--- a/packages/ui-kit/src/MenuButton/components/MenuList/index.tsx
+++ b/packages/ui-kit/src/MenuButton/components/MenuList/index.tsx
@@ -11,7 +11,6 @@ import type { ForwardRefComponent } from '../../../utils/component-helpers/polym
 export interface MenuListProps {
   portal?: boolean;
   children: React.ReactNode;
-  className?: string;
   classes?: {
     popover?: string;
   };

--- a/packages/ui-kit/src/MenuButton/components/MenuList/index.tsx
+++ b/packages/ui-kit/src/MenuButton/components/MenuList/index.tsx
@@ -14,10 +14,12 @@ export interface MenuListProps {
 }
 
 export const MenuList = React.forwardRef(({ portal = true, className, ...props }, forwardedRef) => {
-  const dynamicClasses = cn({
-    [style.menuList]: true,
+  const dynamicClasses = cn(
+    {
+      [style.menuList]: true,
+    },
     className,
-  });
+  );
 
   return (
     <MenuPopover portal={portal}>

--- a/packages/ui-kit/src/MenuButton/components/MenuList/index.tsx
+++ b/packages/ui-kit/src/MenuButton/components/MenuList/index.tsx
@@ -11,9 +11,13 @@ import type { ForwardRefComponent } from '../../../utils/component-helpers/polym
 export interface MenuListProps {
   portal?: boolean;
   children: React.ReactNode;
+  className?: string;
+  classes?: {
+    popover?: string;
+  };
 }
 
-export const MenuList = React.forwardRef(({ portal = true, className, ...props }, forwardedRef) => {
+export const MenuList = React.forwardRef(({ portal = true, className, classes, ...props }, forwardedRef) => {
   const dynamicClasses = cn(
     {
       [style.menuList]: true,
@@ -22,7 +26,7 @@ export const MenuList = React.forwardRef(({ portal = true, className, ...props }
   );
 
   return (
-    <MenuPopover portal={portal}>
+    <MenuPopover className={classes?.popover} portal={portal}>
       <MenuItems {...props} ref={forwardedRef} className={dynamicClasses} />
     </MenuPopover>
   );

--- a/packages/ui-kit/src/MenuButton/components/MenuPopover/index.tsx
+++ b/packages/ui-kit/src/MenuButton/components/MenuPopover/index.tsx
@@ -21,11 +21,13 @@ export const MenuPopover = React.forwardRef(({ as: Comp = 'div', className, ...r
     props,
   } = useDropdownPopover({ ...rest, ref: forwardedRef });
 
-  const dynamicClasses = cn({
-    [style.menuPopover]: true,
-    [style.hidden]: props.hidden,
+  const dynamicClasses = cn(
+    {
+      [style.menuPopover]: true,
+      [style.hidden]: props.hidden,
+    },
     className,
-  });
+  );
 
   return portal ? (
     <Popover {...props} as={Comp} targetRef={targetRef as any} position={position} className={dynamicClasses} />

--- a/packages/ui-kit/src/Popover/index.tsx
+++ b/packages/ui-kit/src/Popover/index.tsx
@@ -45,10 +45,12 @@ const PopoverImpl = forwardRef(function PopoverImpl(
 
   useSimulateTabNavigationForReactTree(targetRef as any, popoverRef);
 
-  const dynamicClasses = cn({
-    [style.popover]: true,
+  const dynamicClasses = cn(
+    {
+      [style.popover]: true,
+    },
     className,
-  });
+  );
 
   return (
     <Comp


### PR DESCRIPTION
We need to pass z-index to MenuPopover, otherwise it gets hidden by panels beneath it. This PR adds `classes` prop to MenuList, which allows passing `popover` classname.

It also fixes passing className prop to MenuList, MenuPopover, DropdownPopover (it was not working correctly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced customization options for the `MenuList` component with the addition of a `classes` property, allowing users to define specific styles for the `MenuPopover`.
  
- **Bug Fixes**
	- Improved readability and maintainability of class name generation in the `DropdownPopover`, `MenuPopover`, and `PopoverImpl` components without altering their functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->