### PR TITLE
feat: add ability to have top placeholder alongside with textarea placeholder

### DIFF
--- a/packages/ui-kit/src/Textarea/Textarea.fixture.tsx
+++ b/packages/ui-kit/src/Textarea/Textarea.fixture.tsx
@@ -31,6 +31,11 @@ const getInputStates = (props: {
     <>
       Placeholder on top: <WrappedTextarea value="test" placeholder="Placeholder" showTopPlaceholder {...props} />
     </>
+
+    <>
+      Placeholder on top + textarea placeholder:
+      <WrappedTextarea value="test" placeholder="Placeholder" showTopPlaceholder topPlaceholder="bio" {...props} />
+    </>
     <>
       Long placeholder on top:
       <WrappedTextarea

--- a/packages/ui-kit/src/Textarea/Textarea.fixture.tsx
+++ b/packages/ui-kit/src/Textarea/Textarea.fixture.tsx
@@ -20,7 +20,7 @@ const getInputStates = (props: {
 }) => (
   <div style={{ display: 'flex', flexFlow: 'column nowrap', gap: '1em' }}>
     <>
-      Empty: <WrappedTextarea value="" placeholder="" {...props} />
+      Empty: <WrappedTextarea value="" {...props} />
     </>
     <>
       Placeholder: <WrappedTextarea placeholder="Placeholder" value="" {...props} />
@@ -29,12 +29,16 @@ const getInputStates = (props: {
       Long placeholder: <WrappedTextarea placeholder="Looooong long long long long placeholder" value="" {...props} />
     </>
     <>
-      Placeholder on top: <WrappedTextarea value="test" placeholder="Placeholder" showTopPlaceholder {...props} />
+      Placeholder is animated to top placeholder:{' '}
+      <WrappedTextarea value="test" placeholder="Placeholder" showTopPlaceholder {...props} />
     </>
-
+    <>
+      Only top placeholder
+      <WrappedTextarea value="test" topPlaceholder="bio" {...props} />
+    </>
     <>
       Placeholder on top + textarea placeholder:
-      <WrappedTextarea value="test" placeholder="Placeholder" showTopPlaceholder topPlaceholder="bio" {...props} />
+      <WrappedTextarea value="test" placeholder="placeholder" topPlaceholder="bio" {...props} />
     </>
     <>
       Long placeholder on top:

--- a/packages/ui-kit/src/Textarea/index.tsx
+++ b/packages/ui-kit/src/Textarea/index.tsx
@@ -116,21 +116,22 @@ function TextareaComponent(
   );
 
   const getPlaceholders = () => {
-    if (!placeholder) return;
+    if (!placeholder && !topPlaceholder) return;
 
-    if (!showTopPlaceholder) {
-      if (value) return;
-      return <div className={cn(s.placeholder, classes?.placeholder)}>{placeholder}</div>;
-    }
-
-    /* Case with both placeholders: on top and over textarea */
-    if (showTopPlaceholder && topPlaceholder) {
+    /* If topPlaceholder is defined always render it on top of textarea */
+    if (topPlaceholder) {
       return (
         <>
           <div className={cn(s.placeholder, classes?.topPlaceholder, s.topPlaceholder)}>{topPlaceholder}</div>
-          {!value && <div className={cn(s.placeholder, classes?.placeholder)}>{placeholder}</div>}
+          {placeholder && !value && <div className={cn(s.placeholder, classes?.placeholder)}>{placeholder}</div>}
         </>
       );
+    }
+
+    /* Case with only teaxtarea placeholder */
+    if (!showTopPlaceholder) {
+      if (value) return;
+      return <div className={cn(s.placeholder, classes?.placeholder)}>{placeholder}</div>;
     }
 
     /* Case where textarea placeholder is animated into top placeholder */

--- a/packages/ui-kit/src/Textarea/index.tsx
+++ b/packages/ui-kit/src/Textarea/index.tsx
@@ -9,6 +9,7 @@ export interface TextareaProps extends React.HTMLProps<HTMLTextAreaElement> {
   message?: string;
   isFocused?: boolean;
   showTopPlaceholder?: boolean;
+  topPlaceholder?: string;
   renderLabel?: JSX.Element | string;
   classes?: {
     inputBox?: string;
@@ -46,6 +47,7 @@ function TextareaComponent(
     isFocused,
     classes,
     showTopPlaceholder = false,
+    topPlaceholder,
     placeholder,
     value,
     maxWidth,
@@ -113,7 +115,7 @@ function TextareaComponent(
     [onChange],
   );
 
-  const getPlaceholder = () => {
+  const getPlaceholders = () => {
     if (!placeholder) return;
 
     if (!showTopPlaceholder) {
@@ -121,6 +123,17 @@ function TextareaComponent(
       return <div className={cn(s.placeholder, classes?.placeholder)}>{placeholder}</div>;
     }
 
+    /* Case with both placeholders: on top and over textarea */
+    if (showTopPlaceholder && topPlaceholder) {
+      return (
+        <>
+          <div className={cn(s.placeholder, classes?.topPlaceholder, s.topPlaceholder)}>{topPlaceholder}</div>
+          {!value && <div className={cn(s.placeholder, classes?.placeholder)}>{placeholder}</div>}
+        </>
+      );
+    }
+
+    /* Case where textarea placeholder is animated into top placeholder */
     return (
       <div className={cn(s.placeholder, classes?.topPlaceholder, value && showTopPlaceholder && s.topPlaceholder)}>
         {placeholder}
@@ -132,7 +145,7 @@ function TextareaComponent(
     <div className={cn(s.root, className, dynamicClasses)}>
       {renderLabel && <div className={cn(s.label, classes?.label)}>{renderLabel}</div>}
       <div className={cn(s.inputBox, classes?.inputBox)}>
-        {getPlaceholder()}
+        {getPlaceholders()}
 
         {children && <div className={s.icons}>{children}</div>}
         <textarea


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/8fa9335e-8a87-44b9-b8c3-1c9b8e3be5f7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `topPlaceholder` property for the `WrappedTextarea` component, allowing an additional placeholder above the textarea.
	- Enhanced placeholder rendering to support both top and standard placeholders.

- **Tests**
	- Added new test cases for the `WrappedTextarea` to validate behavior with various placeholder configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->