### PR TITLE
feat(Legend): allow to set showSteps separately for each axis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20591,7 +20591,7 @@
     },
     "packages/default-icons": {
       "name": "@konturio/default-icons",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "devDependencies": {
         "@figma-export/cli": "^4.3.0",
         "@figma-export/output-components-as-svgr": "^4.2.0",
@@ -20607,7 +20607,7 @@
     },
     "packages/floating": {
       "name": "@konturio/floating",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "@floating-ui/react": "^0.27.8",
         "nanoid": "^4.0.0"
@@ -20635,10 +20635,10 @@
     },
     "packages/ui-kit": {
       "name": "@konturio/ui-kit",
-      "version": "5.4.3",
+      "version": "5.4.4",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.2",
-        "@konturio/floating": "^1.2.1",
+        "@konturio/floating": "^1.2.2",
         "downshift": "^8.0.0",
         "nanoid": "^4.0.2",
         "react-is": "^18.2.0",

--- a/packages/ui-kit/src/Legend/Legend.fixture.tsx
+++ b/packages/ui-kit/src/Legend/Legend.fixture.tsx
@@ -251,5 +251,60 @@ export default (
       }}
       title={'Custom Axis Labels'}
     />
+
+    <Legend
+      showSteps={{ x: false, y: true }}
+      showArrowHeads={true}
+      showAxisLabels={true}
+      size={2}
+      cells={[
+        { label: 'A1', color: 'gray' },
+        { label: 'B1', color: 'silver' },
+
+        { label: 'A2', color: 'silver' },
+        { label: 'B2', color: 'gray' },
+
+        { label: 'A3', color: 'gray' },
+        { label: 'B3', color: 'silver' },
+
+        { label: 'A4', color: 'silver' },
+        { label: 'B4', color: 'gray' },
+      ]}
+      axis={{
+        x: {
+          label: 'X axis',
+          quality: 2,
+          quotient: ['quotient1', 'quotient2'],
+          steps: [
+            {
+              value: 0,
+            },
+            {
+              value: 3,
+            },
+            {
+              value: 6,
+            },
+          ],
+        },
+        y: {
+          label: 'Y axis',
+          quality: 3,
+          quotient: ['quotient1', 'quotient2'],
+          steps: [
+            {
+              value: 0.0,
+            },
+            {
+              value: 0.3,
+            },
+            {
+              value: 0.6,
+            },
+          ],
+        },
+      }}
+      title={'Hide steps for separate axis'}
+    />
   </>
 );

--- a/packages/ui-kit/src/Legend/index.tsx
+++ b/packages/ui-kit/src/Legend/index.tsx
@@ -33,7 +33,7 @@ export interface LegendProps<
   size: number;
   title?: string;
   showAxisLabels?: boolean;
-  showSteps?: boolean;
+  showSteps?: boolean | { x: boolean; y: boolean };
   showArrowHeads?: boolean;
   axis: Axis;
   onCellPointerOver?: (e: MouseEvent, cell: Cell, i: number) => void;
@@ -89,7 +89,7 @@ export function Legend<
   );
 
   const gridCells = fillTemplate(TEMPLATE, {
-    x: showSteps
+    x: (typeof showSteps === 'object' ? showSteps.x : showSteps)
       ? axis.x.steps.map((step) => ({
           label: step.label || step.value.toFixed(1),
           className: styles.xStepsCell,
@@ -98,7 +98,7 @@ export function Legend<
           label: '',
           className: styles.xStepsCellNoLabel,
         })),
-    y: showSteps
+    y: (typeof showSteps === 'object' ? showSteps.y : showSteps)
       ? safeReverse(axis.y.steps).map((step) => ({
           label: step.label || step.value.toFixed(1),
           className: styles.yStepsCell,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to independently control the visibility of step labels on the x and y axes in the Legend component.
  * Introduced a new example demonstrating this selective step visibility in the Legend component showcase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->